### PR TITLE
launcher

### DIFF
--- a/scripts/pymca_launcher
+++ b/scripts/pymca_launcher
@@ -31,6 +31,7 @@ understood: edfviewer, elementsinfo, mca2edf, peakidentifier, pymca,
 pymcabatch, pymcapostbatch, pymcaroitool, rgbcorrelator
 """
 import argparse
+import os
 import sys
 from importlib import import_module
 
@@ -54,7 +55,7 @@ shortcuts = {
 parser = argparse.ArgumentParser(description=__doc__)
 # first command line argument
 parser.add_argument('command',
-                    nargs='?', default="PyMca5.PyMcaGui.pymca.PyMcaMain",
+                    nargs='?',
                     help='Name of module whose main() function you want to' +
                          ' run, or "help" to print a help message. If this' +
                          ' argument is omitted, run "PyMcaMain"')
@@ -70,13 +71,12 @@ if len(sys.argv) > 1 and sys.argv[1].startswith("-")\
     # example: pymca_launcher -f ...
     # In that case, the parser raises a SystemExit (unrecognized arguments)
     class Args:
-        command = "PyMca5.PyMcaGui.pymca.PyMcaMain"
-        parser.mainargs = sys.argv[1:]
+        command = None
+        mainargs = sys.argv[1:]
 
     args = Args()
 else:
     args = parser.parse_args()
-
 
 print_docstring = False
 if args.command == "help":
@@ -91,6 +91,8 @@ if args.command == "help":
 
 if args.command in shortcuts:
     modname = shortcuts[args.command]
+elif args.command is None:
+    modname = "PyMca5.PyMcaGui.pymca.PyMcaMain"
 else:
     modname = args.command
 
@@ -125,7 +127,8 @@ if print_docstring:
     sys.exit(0)
 
 # remove launcher script from the command line
-sys.argv = sys.argv[1:]
+if args.command is not None:
+    sys.argv = sys.argv[1:]
 
 # run main() function
 if hasattr(m, "main"):
@@ -133,12 +136,12 @@ if hasattr(m, "main"):
     status = main(*args.mainargs)
     sys.exit(status)
 
-# try executing the source file
+# try executing the .py source file
 else:
     fname = m.__file__
+    if fname.endswith(".pyc") and os.path.exists(fname[:-1]):
+        fname = fname[:-1]
     if sys.version < '3.0':
         execfile(fname)
     else:
         exec(compile(open(fname).read(), fname, 'exec'))
-
-# TODO: rst2man

--- a/scripts/pymca_launcher
+++ b/scripts/pymca_launcher
@@ -67,7 +67,7 @@ parser.add_argument('mainargs', nargs=argparse.REMAINDER,
 if len(sys.argv) > 1 and sys.argv[1].startswith("-")\
         and not sys.argv[1] in ["-h", "--help"]:
     # special case with no command but optional arguments for PyMcaMain
-    # example: pymca_launcher.py -f ...
+    # example: pymca_launcher -f ...
     # In that case, the parser raises a SystemExit (unrecognized arguments)
     class Args:
         command = "PyMca5.PyMcaGui.pymca.PyMcaMain"
@@ -81,11 +81,11 @@ else:
 print_docstring = False
 if args.command == "help":
     if args.mainargs:
-        # pymca_launcher.py help command
+        # pymca_launcher help command
         print_docstring = True
         args.command = args.mainargs[0]
     else:
-        # pymca_launcher.py help
+        # pymca_launcher help
         parser.print_help()
         parser.exit()
 

--- a/scripts/pymca_launcher.bat
+++ b/scripts/pymca_launcher.bat
@@ -1,0 +1,2 @@
+@echo off
+python "%~dpn0" %*

--- a/scripts/pymca_launcher.py
+++ b/scripts/pymca_launcher.py
@@ -1,3 +1,4 @@
+#! /usr/bin/python 
 # coding: utf-8
 #/*##########################################################################
 # Copyright (C) 2016 European Synchrotron Radiation Facility
@@ -35,7 +36,7 @@ from importlib import import_module
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "02/08/2016"
+__date__ = "16/08/2016"
 
 # shortcut commands (previous scripts)
 shortcuts = {
@@ -57,12 +58,25 @@ parser.add_argument('command',
                     help='Name of module whose main() function you want to' +
                          ' run, or "help" to print a help message. If this' +
                          ' argument is omitted, run "PyMcaMain"')
+
 # remaining command-line arguments
 parser.add_argument('mainargs', nargs=argparse.REMAINDER,
                     help='Arguments passed to the main() function, or name' +
                          ' of a module if command is "help"')
 
-args = parser.parse_args()
+if len(sys.argv) > 1 and sys.argv[1].startswith("-")\
+        and not sys.argv[1] in ["-h", "--help"]:
+    # special case with no command but optional arguments for PyMcaMain
+    # example: pymca_launcher.py -f ...
+    # In that case, the parser raises a SystemExit (unrecognized arguments)
+    class Args:
+        command = "PyMca5.PyMcaGui.pymca.PyMcaMain"
+        parser.mainargs = sys.argv[1:]
+
+    args = Args()
+else:
+    args = parser.parse_args()
+
 
 print_docstring = False
 if args.command == "help":
@@ -126,6 +140,5 @@ else:
         execfile(fname)
     else:
         exec(compile(open(fname).read(), fname, 'exec'))
-
 
 # TODO: rst2man

--- a/scripts/pymca_launcher.py
+++ b/scripts/pymca_launcher.py
@@ -1,0 +1,97 @@
+# coding: utf-8
+#/*##########################################################################
+# Copyright (C) 2016 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#############################################################################*/
+"""Command line interface to execute main() functions in PyMca5 modules.
+"""
+import argparse
+# import pkgutil
+import os
+import sys
+from importlib import import_module
+
+__authors__ = ["P. Knobel"]
+__license__ = "MIT"
+__date__ = "22/07/2016"
+
+# small number of shortcut commands
+shortcuts = {
+    '': "PyMcaMain",
+    'edfviewer': "EdfFileSimpleViewer"
+# TODO
+}
+
+parser = argparse.ArgumentParser(description='pymca generic launcher')
+# first command line argument
+parser.add_argument('command',
+                    nargs='?', default="",
+                    help='name of module whose main() function you want to run')
+# remaining command-line arguments
+parser.add_argument('mainargs', nargs='*',
+                    help='arguments passed to the main() function')
+
+args = parser.parse_args()
+
+if args.command in shortcuts:
+    modname = shortcuts[args.command]
+else:
+    modname = args.command
+
+try:
+    # if command is a fully qualified module name
+    m = import_module(modname)
+except ImportError:
+    # try prepending PyMca5
+    try:
+        m = import_module("PyMca5.PyMca." + modname)
+    except ImportError:
+        m = None
+
+if m is None:
+    print("No module or command " + args.command + " found")
+    sys.exit(1)
+
+try:
+    main = getattr(m, "main")
+except AttributeError:
+    # if module does not have a amin function, try executing the source file
+    # (is this a good idea?)
+    if not args.command == '':
+        # remove module or command for command-line arguments
+        sys.argv = sys.argv[1:]
+    fname = m.__file__
+    if sys.version < '3.0':
+        execfile(fname)
+    else:
+        exec(compile(open(fname).read(), fname, 'exec'))
+else:
+    # This will work for modules with a main() function
+    status = main(*args.mainargs)
+
+    # if status is an int, it is considered an exit status
+    # (could be 0 for success, 1 for general errors, 2 for command line syntax error…)
+    # None is equivalent to 0, any other object is printed to stderr and results
+    # in an exit code of 1
+    sys.exit(status)
+
+
+# TODO: help (main.__doc__), rst2man

--- a/scripts/pymca_launcher.py
+++ b/scripts/pymca_launcher.py
@@ -21,7 +21,13 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-"""Command line interface to execute main() functions in PyMca5 modules.
+"""This program can be used to execute any PyMca5 module by providing a module
+name as the first command line argument. The module name can be either a fully
+qualified name, or a short module name.
+
+A few shortcut commands, corresponding to legacy PyMca scripts, are also
+understood: edfviewer, elementsinfo, mca2edf, peakidentifier, pymca,
+pymcabatch, pymcapostbatch, pymcaroitool, rgbcorrelator
 """
 import argparse
 import sys
@@ -29,18 +35,25 @@ from importlib import import_module
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "01/08/2016"
+__date__ = "02/08/2016"
 
-# small number of shortcut commands
+# shortcut commands (previous scripts)
 shortcuts = {
-    'edfviewer': "EdfFileSimpleViewer"
-    # TODO
+    'edfviewer': "PyMca5.PyMcaGui.pymca.EdfFileSimpleViewer",
+    'elementsinfo': "PyMca5.PyMcaGui.physics.xrf.ElementsInfo",
+    'mca2edf': "PyMca5.PyMcaGui.pymca.Mca2Edf",
+    'peakidentifier': "PyMca5.PyMcaGui.PeakIdentifier",
+    'pymca': "PyMca5.PyMcaGui.pymca.PyMcaMain",
+    'pymcabatch': "PyMca5.PyMcaGui.pymca.PyMcaBatch",
+    'pymcapostbatch': "PyMca5.PyMcaGui.pymca.PyMcaPostBatch",
+    'pymcaroitool': "PyMca5.PyMcaGui.pymca.QStackWidget",
+    'rgbcorrelator': "PyMca5.PyMcaGui.pymca.PyMcaPostBatch",
 }
 
 parser = argparse.ArgumentParser(description=__doc__)
 # first command line argument
 parser.add_argument('command',
-                    nargs='?', default="PyMcaMain",
+                    nargs='?', default="PyMca5.PyMcaGui.pymca.PyMcaMain",
                     help='Name of module whose main() function you want to' +
                          ' run, or "help" to print a help message. If this' +
                          ' argument is omitted, run "PyMcaMain"')
@@ -83,7 +96,6 @@ if m is None:
 
 # help
 if print_docstring:
-    print("i can haz ")
     if m.__doc__ is not None:
         msg = "Module docstring:\n" + m.__doc__ + "\n\n"
     else:

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,12 @@
 
 __authors__ = ["V.A. Sole"]
 __license__ = "MIT"
-__date__ = "2/07/2016"
+__date__ = "16/08/2016"
 
+import glob
+import os
 from setuptools import setup
+
 
 version = "5.1.2"
 name = "pymca"
@@ -31,6 +34,9 @@ description = "pymca"
 f = open("README.rst")
 long_description = f.read()
 f.close()
+
+scripts = glob.glob(os.path.join("scripts", "*"))
+
 classifiers = ["Development Status :: 5 - Production/Stable",
                "Environment :: Console",
                "Environment :: MacOS X",
@@ -59,4 +65,5 @@ if __name__ == "__main__":
           description=description,
           long_description=long_description,
           install_requires=install_requires,
+          scripts=scripts
           )


### PR DESCRIPTION
This script can launch any PyMca5 module. The user can provide a fully qualified module name (`python3 pymca_launcher.py PyMca5.PyMcaGui.physics.xrf.ElementsInfo`) or a short name (`python pymca_launcher.py ElementsInfo`).

If no module is specified (i.e. `python pymca_launcher.py`), the default choice is `PyMca5.PyMcaGui.pymca.PyMcaMain`.

A few commands, corresponding to the current PyMca script names, are also understood:
- _edfviewer_: PyMca5.PyMcaGui.pymca.EdfFileSimpleViewer
- _elementsinfo_: PyMca5.PyMcaGui.physics.xrf.ElementsInfo
- _mca2edf_: PyMca5.PyMcaGui.pymca.Mca2Edf
- _peakidentifier_: PyMca5.PyMcaGui.PeakIdentifier
- _pymca_: PyMca5.PyMcaGui.pymca.PyMcaMain
- _pymcabatch_: PyMca5.PyMcaGui.pymca.PyMcaBatch
- _pymcapostbatch_: PyMca5.PyMcaGui.pymca.PyMcaPostBatch
- _pymcaroitool_: PyMca5.PyMcaGui.pymca.QStackWidget
- _rgbcorrelator_: PyMca5.PyMcaGui.pymca.PyMcaPostBatch

If a `main` function is present in the module, it is executed and extra command line arguments are passed to it. The return value of the function is used as exit code: `None` and `0` cause an exit code of 0, integers are used directly as exit codes, any other returned object causes an exit code of 1 and is printed to `stderr` (this is the standard behavior of `sys.exit(…)`)

In the absence of a `main` function, the module is executed with `exec` or `execfile`.

The `help` command, followed by a valid command or module name, causes the docstrings to be printed (module level `__doc__` and `main.__doc__` if a main function is present).

Known issues:
- with python 2, many modules cause a `SyntaxError: Non-ASCII character '\xf3' in file ….pyc on line 1, but no encoding declared`. This includes PyMcaMain, PlotWindow, PyMcaPostBatch, QStackWidget (pymcaroitool)… I don't understand this error. As far I can tell, there are no visible non-ascii characters on the first line of these modules.
- modules with relative imports and without a main function cause a `SystemError: Parent module '' not loaded, cannot perform relative import` (RGBCorrelatorGraph, PlotWindow…).  This can be solved by replacing `if __name__ == "__main__"`  by `def main():` in modules that need to be executable, so that they are not executed as scripts. Should we catch the error and print a more helpful error message for modules that use relative imports and don't define a `main()`?
- the current behavior is that if a main function is defined, remaining command line arguments are passed to that function. This requires the main signature to be `main(*args)`. Is that what we want, or should we leave it to the main function to check for `sys.argv` and enforce that main() should take no mandatory arguments?
